### PR TITLE
Add Dependabot config and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @SRWieZ

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "Europe/Paris"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Forward-looking baseline ahead of any GitHub Actions workflows landing in this repo. Once workflows exist, Dependabot will keep their pinned SHAs up to date automatically (monthly, grouped, labelled).

Part of the fleet-wide hardening pass triggered by [Composer CVE-2026-45793](https://github.com/composer/composer/security/advisories/GHSA-f9f8-rm49-7jv2). Same template as [knotsphp/publicip#6](https://github.com/knotsphp/publicip/pull/6) (minus the workflow changes that do not apply here yet).

- Add `.github/dependabot.yml` (monthly, grouped, labelled)
- Add `.github/CODEOWNERS`